### PR TITLE
Update Readme > describe how to use arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Get your localized text in Handlebars.
 Example: `{{i18n "store.purchase"}}`.
 
 
+## `{{i18n "sayHello" userName}}`
+
+Provide arguments
+
 
 ## `i18n.map(language, map)`
 
@@ -36,7 +40,7 @@ Add new text map.
 Example:
 
     i18n.map('en', {
-      hello: 'world',
+      sayHello: 'Hi {$1}',
       store: {
         purchase: 'buy now',
         basket: 'basket',


### PR DESCRIPTION
I was wondering, that the package doesn't support arguments by default, and looked into the code, and found it.
I guess, others should know about it from the docs ;)