### PR TITLE
Fix use of deprecated API in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,10 +6,10 @@ Package.describe({
 });
 
 Package.on_use(function (api, where) {
-  api.versionsFrom('0.9.0');
+  api.versionsFrom('1.0.0');
   api.use(['underscore', 'ui', 'deps'], ['client', 'server']);
   api.export('i18n', ['client', 'server']);
-  api.add_files('i18n.js', ['client', 'server']);
+  api.addFiles('i18n.js', ['client', 'server']);
 });
 
 // Package.on_test(function(api){


### PR DESCRIPTION
Fixes use of deprecated API in `package.js` which has been finally removed in Meteor 2.3